### PR TITLE
Fixed website icon not showing in compatibility page

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -31,7 +31,7 @@
     <!-- Texts -->
     <script src="texts/compatibility.js"></script>
 
-    <link rel=icon href="favicon.ico" sizes="any" type="image/svg+xml">
+    <link rel="shortcut icon" href="favicon.ico">
 
 </head>
 

--- a/compatibility.html
+++ b/compatibility.html
@@ -31,7 +31,7 @@
     <!-- Texts -->
     <script src="texts/compatibility.js"></script>
 
-    <link rel=icon href=img/logo.svg sizes="any" type="image/svg+xml">
+    <link rel=icon href="favicon.ico" sizes="any" type="image/svg+xml">
 
 </head>
 


### PR DESCRIPTION
The previous .svg seems to work on firefox and microsoft edge but not chrome