### PR TITLE
Removed Maidump method, added vpk creation steps

### DIFF
--- a/quickstart.html
+++ b/quickstart.html
@@ -116,7 +116,7 @@ texts: compatibility
 <section class="bg-dark text-white pt-5">
     <div class="container">
         <h1 class="text-center mb-5">Dumping Games</h1>
-        <p>Vita3K does <b class="text-danger">not</b> condone piracy, therefore, you are required to dump your own games.</p>
+        <p>Vita3K does <b class="text-danger">not</b> condone piracy, therefore, you are required to dump your own games.  Currently, it is preferred to dump your games on a Vita or Vita TV (PS TV) using HENkaku <b class="text-danger">3.60 - 3.65</b>.</p>
         <p>Currently, Vita3K supports .pkg, NoNpDrm, FAGDec, or manually decrypted games (Vitamin dumps are not supported and Maidump is unstable).
             The games should be in a .zip or .vpk format if you want to install them from the emulator, or if you prefer to copy them yourself,
             you can drag and drop the game folder in your <code>pref_path/ux0/app</code> folder (not applicable for NoNpDrm dumps/.pkg files).</p>
@@ -220,7 +220,7 @@ texts: compatibility
             <div class="answer">
                 <div class="padding-wrapper">
                     <ol>
-                        <li>Download <a href="https://github.com/vitaorganizer/vitaorganizer/releases">VitaOrganizer</a> run the application on your PC.</li>
+                        <li>Download <a href="https://github.com/vitaorganizer/vitaorganizer/releases">VitaOrganizer</a> and run the application on your PC.</li>
                         <li>Click <code>File</code> -> <code>Create vpk from maidump folder...</code></li>
                         <li>Select the <code>EBOOT.BIN</code> file inside of your dump folder.</li>
                         <p>The progress of the vpk creation will be shown at the bottom of the VitaOrganizer window. Once it's completed, open Vita3K and drag the vpk onto the Vita3K window.</p>

--- a/quickstart.html
+++ b/quickstart.html
@@ -231,7 +231,6 @@ texts: compatibility
                     </div>
                 </div>
             </div>
-        <div class="my-5">
         </div>
     </div>
 </section>

--- a/quickstart.html
+++ b/quickstart.html
@@ -185,7 +185,6 @@ texts: compatibility
                             </div>
                         </div>
                     
-                    
                     </div>
                 </div>
                 <div class="accordion-item">

--- a/quickstart.html
+++ b/quickstart.html
@@ -117,7 +117,7 @@ texts: compatibility
     <div class="container">
         <h1 class="text-center mb-5">Dumping Games</h1>
         <p>Vita3K does <b class="text-danger">not</b> condone piracy, therefore, you are required to dump your own games.</p>
-        <p>Currently, Vita3K supports maidumps, .pkg, NoNpDrm, FAGDec, or manually decrypted games (Vitamin dumps are not supported).
+        <p>Currently, Vita3K supports .pkg, NoNpDrm, FAGDec, or manually decrypted games (Vitamin dumps are not supported and Maidump is unstable).
             The games should be in a .zip or .vpk format if you want to install them from the emulator, or if you prefer to copy them yourself,
             you can drag and drop the game folder in your <code>pref_path/ux0/app</code> folder (not applicable for NoNpDrm dumps/.pkg files).</p>
         <p><code>pref_path</code> defaults to:
@@ -171,7 +171,7 @@ texts: compatibility
                         </div>
                     </div>
                 </div>
-                <div class="accordion-item">
+                <div class="accordion-item" style="display: none;">
                     <div role="tab" id="nonpdrmHeader">
                         <a class="accordion-link collapsed" data-toggle="collapse" data-parent="#accordion" aria-expanded="false"
                         aria-controls="nonpdrm" href="#nonpdrm">
@@ -213,41 +213,18 @@ texts: compatibility
                         </div>
                     </div>
                 </div>
-                <div class="accordion-item">
-                    <div role="tab" id="maidumpHeader">
-                        <a class="accordion-link collapsed" data-toggle="collapse" data-parent="#accordion" aria-expanded="false"
-                        aria-controls="maidump" href="#maidump">
-                        Maidump (+Vitashell)
-                        <i class="icon ion-md-add-circle"></i>
-                        <i class="icon ion-md-remove-circle"></i>
-                        </a>
-                    </div>
-                    <div class="collapse" id="maidump" role="tabpanel" aria-labelledby="maidumpHeader" data-parent="#accordion">
-                        <div class="answer">
-                            <div class="padding-wrapper">
-                                <p class="my-3"><h5>Using <a href="https://github.com/LioMajor/MaiDumpToolEN/releases">Maidump</a> 
-                                    (and optionally <a href="https://github.com/TheOfficialFloW/VitaShell/releases">Vitashell</a>)</h5></p>
-                                <ol class="my-3">
-                                    <p>It's recommended you use Vitashell with maidump here as it's more stable this way.</p>
-                                    <li>Install maidump</li>
-                                    <li>Launch maidump and select <code>Extract/Decrypt content</code></li>
-                                    <li>Choose the game you want to dump and press the <code>◯</code> button</li>
-                                    <li>
-                                        <ol type="A">
-                                        <li>If you're using Vitashell:</li>
-                                        <p class="my-2">Select <code>Decrypt eboot only(incl. suprx)</code> and wait for it to decrypt.</p>
-                                        <p class="my-2">Then dump the game files using Vitashell by following the steps in the first method from steps 2-4.</p>
-                                        <p>Copy the dumped files from <code>ux0:mai/'title_id'</code> into your previously copied folder from VitaShell.</p>
-                                        <li>If you're not using Vitashell:</li>
-                                        <p class="my-2">Select <code>Extract the game and decrypt eboot (incl. suprx)</code>.</p>
-                                        <p class="my-2">Wait for the game to finish dumping (dumping sometimes fails since maidump is unstable).</p>
-                                        <p>You can find your dumped game in <code>ux0:mai/'title_id'</code>.</p>
-                                        </ol>
-                                    </li>
-                                </ol>
-                            </div>
-                        </div>
-                    </div>
+            </div>
+        <div class="my-5">
+            <h3>Building a .vpk file</h3>
+            <p class="my-3">After dumping your game, you can optionally package it into a .vpk file for Vita3K to install. By packaging your dump into a .vpk, you can drag and drop it directly into the Vita3K window to install it.</p>
+            <div class="answer">
+                <div class="padding-wrapper">
+                    <ol>
+                        <li>Download <a href="https://github.com/vitaorganizer/vitaorganizer/releases">VitaOrganizer</a> run the application on your PC.</li>
+                        <li>Click <code>File</code> -> <code>Create vpk from maidump folder...</code></li>
+                        <li>Select the <code>EBOOT.BIN</code> file inside of your dump folder.</li>
+                        <p>The progress of the vpk creation will be shown at the bottom of the VitaOrganizer window. Once it's completed, open Vita3K and drag the vpk onto the Vita3K window.</p>
+                    </ol>
                 </div>
             </div>
         </div>

--- a/quickstart.html
+++ b/quickstart.html
@@ -169,9 +169,26 @@ texts: compatibility
                                 </ol>
                             </div>
                         </div>
+                        
+                        <div class="answer">
+                            <div class="padding-wrapper">
+                                <h5 class="my-3">Building a .vpk file</h5>
+                                <p class="my-3">
+                                    After dumping your game, you can optionally package it into a .vpk file for Vita3K to install. By packaging your dump into a .vpk, you can drag and drop it directly into the Vita3K window to install it.
+                                </p>
+                                <ol>
+                                    <li>Download <a href="https://github.com/vitaorganizer/vitaorganizer/releases">VitaOrganizer</a> and run the application on your PC.</li>
+                                    <li>Click <code>File</code> -> <code>Create vpk from maidump folder...</code></li>
+                                    <li>Select the <code>EBOOT.BIN</code> file inside of your dump folder.</li>
+                                    <p>The progress of the vpk creation will be shown at the bottom of the VitaOrganizer window. Once it's completed, open Vita3K and drag the vpk onto the Vita3K window.</p>
+                                </ol>
+                            </div>
+                        </div>
+                    
+                    
                     </div>
                 </div>
-                <div class="accordion-item" style="display: none;">
+                <div class="accordion-item">
                     <div role="tab" id="nonpdrmHeader">
                         <a class="accordion-link collapsed" data-toggle="collapse" data-parent="#accordion" aria-expanded="false"
                         aria-controls="nonpdrm" href="#nonpdrm">
@@ -215,18 +232,6 @@ texts: compatibility
                 </div>
             </div>
         <div class="my-5">
-            <h3>Building a .vpk file</h3>
-            <p class="my-3">After dumping your game, you can optionally package it into a .vpk file for Vita3K to install. By packaging your dump into a .vpk, you can drag and drop it directly into the Vita3K window to install it.</p>
-            <div class="answer">
-                <div class="padding-wrapper">
-                    <ol>
-                        <li>Download <a href="https://github.com/vitaorganizer/vitaorganizer/releases">VitaOrganizer</a> and run the application on your PC.</li>
-                        <li>Click <code>File</code> -> <code>Create vpk from maidump folder...</code></li>
-                        <li>Select the <code>EBOOT.BIN</code> file inside of your dump folder.</li>
-                        <p>The progress of the vpk creation will be shown at the bottom of the VitaOrganizer window. Once it's completed, open Vita3K and drag the vpk onto the Vita3K window.</p>
-                    </ol>
-                </div>
-            </div>
         </div>
     </div>
 </section>


### PR DESCRIPTION
Maidump is not recommended for Vita dumping anymore, not even in specific deep circles of Vita dumping. This is because Maidump is unstable, and has lead to games being modified to somewhat work. Maidump is not well-supported, even on real Vitas and Vita TVs. The usage of Maidump can and will lead to your original game files being corrupted, forcing a re-installation of the game from the PlayStation Store, where the other methods will not result in corruption this way.

The addition of VPK creation is straightforward. It assumes that you've created a dump, rather than installed a VPK from other sources. As Vita3K wants to support users dumping their own cartridges and PSN games, this helps users into an easier method of installing games on Vita3K legitimately.